### PR TITLE
Complete secondary Claude bootstrap linkage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 4. 관련 문서 및 열린 GitHub Issue
 5. 코드 작업이라면 관련 PR/최근 변경사항
 
+Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`를 읽고, 필요 시 `docs/CLAUDE_SECONDARY_START_PROMPT.md`를 시작 프롬프트로 사용한다.
+
 대화 기억만으로 현재 상태를 추정하지 않는다.
 
 ## 2. 작업 단위
@@ -16,6 +18,8 @@
 - Issue 없이 큰 기능을 바로 개발하지 않는다.
 - 기존 작업과 중복되는지 먼저 검색한다.
 - 아이디어/메모/녹취/메일은 먼저 `Inbox` 성격으로 기록한 뒤 실행 가능한 Issue로 정리한다.
+- 여러 Claude를 병렬로 사용할 때는 **한 Issue = 한 실행 Claude**, **한 작업 = 전용 branch**를 기본으로 한다.
+- 다른 Claude가 진행 중인 Issue/branch를 임의로 덮어쓰지 않는다.
 
 ## 3. 기본 상태
 일반 작업: `Inbox → Planned → Todo → In Progress → Review → Done`
@@ -48,6 +52,7 @@
 - 운영에 영향이 큰 변경은 가능하면 `main`에 직접 커밋하지 않는다.
 - 기존 파일을 대량 삭제하거나 구조를 크게 바꾸기 전에는 사용자 승인을 받는다.
 - Secret/API Key/개인정보를 저장소에 커밋하지 않는다.
+- 병렬 Claude 작업 시 개발 전 예상 변경 파일을 확인하고, 같은 핵심 파일을 동시에 수정할 가능성이 높으면 먼저 사용자/ChatGPT에게 알린다.
 
 ## 7. 문서 위치
 - 현재 상태: `docs/PROJECT_STATE.md`
@@ -55,6 +60,8 @@
 - 주요 의사결정: `docs/DECISIONS.md`
 - 프로젝트/Issue 관리 규칙: `docs/PROJECT_MANAGEMENT.md`
 - ChatGPT→Claude 인수인계: `docs/CHATGPT_CLAUDE_HANDOFF.md`
+- Claude 계정/세션 복원: `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`
+- 2차 Claude 시작 프롬프트: `docs/CLAUDE_SECONDARY_START_PROMPT.md`
 - 작품 콘텐츠 기획: `docs/content/`
 - 기능 기획: `docs/product/`
 - QA: `docs/qa/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,33 @@
 Claude는 작업 시작 시 반드시 다음을 읽는다.
 
 1. `AGENTS.md`
-2. `docs/PROJECT_STATE.md`
-3. `docs/ROADMAP.md`
-4. `docs/CHATGPT_CLAUDE_HANDOFF.md`
-5. 관련 GitHub Issue
-6. 연결된 기획문서
-7. 관련 코드/최근 PR
+2. `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`
+3. `docs/PROJECT_STATE.md`
+4. `docs/ROADMAP.md`
+5. `docs/CHATGPT_CLAUDE_HANDOFF.md`
+6. 관련 GitHub Issue
+7. 연결된 기획문서
+8. 관련 코드/최근 PR
+
+새 Claude 계정/새 Claude Project/새 Claude Code 세션에서 시작할 때는 `docs/CLAUDE_SECONDARY_START_PROMPT.md`를 최초 시작 프롬프트로 사용할 수 있다.
 
 ## Claude의 기본 역할
 Claude는 이 프로젝트의 **개발자/기술검토자**를 기본 역할로 한다. ChatGPT가 작성한 기획안을 그대로 구현하는 사람이 아니라, 먼저 현재 코드와 비교해 기술적으로 검토하고 필요한 질문을 한 뒤 승인된 범위만 개발한다.
+
+## 새 Claude 계정/세션 부트스트랩
+Claude 계정이나 채팅이 바뀌어도 개발자 역할은 GitHub에서 복원한다.
+
+- 기준 문서: `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`
+- 복사용 시작 프롬프트: `docs/CLAUDE_SECONDARY_START_PROMPT.md`
+- 과거 Claude 대화 기억을 필수 전제로 삼지 않는다.
+- 첫 답변은 구현보다 프로젝트 복원/충돌 점검/기술검토 보고를 우선한다.
+
+### 여러 Claude 병렬 작업 규칙
+- **한 Issue = 한 실행 Claude**를 기본으로 한다.
+- **한 작업 = 전용 branch**를 사용한다.
+- 다른 Claude가 진행 중인 Issue/branch를 임의로 덮어쓰지 않는다.
+- 개발 전 예상 변경 파일을 확인하고, 같은 핵심 파일을 동시에 건드릴 가능성이 높으면 사용자/ChatGPT에게 먼저 알린다.
+- 인수인계 시 Issue에 완료한 것, 남은 것, branch/PR, 테스트 결과, 다음 행동을 남긴다.
 
 ## 콘텐츠 관련 Handoff 추가 규칙
 신규 작품 콘텐츠, 기존 작품 대규모 확장, 등장인물/장소/해시태그 데이터 구조, 후킹 페이지·지도·퀴즈·여행코스 관련 개발을 검토할 때는 다음 공용 스킬을 추가로 반드시 읽는다.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,12 @@
 - [`CHATGPT_CLAUDE_HANDOFF.md`](CHATGPT_CLAUDE_HANDOFF.md)  
   ChatGPT 기획안을 GitHub를 통해 Claude에게 넘기고, 기술검토·사용자 승인 후 개발하는 표준 절차.
 
+- [`CLAUDE_DEVELOPER_BOOTSTRAP.md`](CLAUDE_DEVELOPER_BOOTSTRAP.md)  
+  다른 Claude 계정/세션에서도 동일한 개발자 역할을 GitHub 기준으로 복원하고 병렬 작업 충돌을 방지하는 가이드.
+
+- [`CLAUDE_SECONDARY_START_PROMPT.md`](CLAUDE_SECONDARY_START_PROMPT.md)  
+  2차 Claude 계정·Project·Code 세션에 그대로 붙여 넣는 시작 프롬프트.
+
 - [`ROADMAP.md`](ROADMAP.md)  
   AI 공동개발 기반 구축부터 Inbox·자동보고·멀티에이전트 고도화까지의 단계별 로드맵.
 
@@ -74,11 +80,13 @@ docs/
 1. GitHub를 프로젝트의 Single Source of Truth로 사용한다.
 2. 코드·문서는 Repository, 할 일은 Issues, 진행상태는 GitHub Projects에서 관리한다.
 3. 새로운 AI/개발자는 `AGENTS.md → PROJECT_STATE.md → CHATGPT_CLAUDE_HANDOFF.md → 열린 Issues` 순으로 확인한다.
-4. ChatGPT 기획이 개발로 넘어갈 때는 Handoff Issue와 사용자 승인 Gate를 사용한다.
-5. Markdown을 기본 관리 포맷으로 사용한다.
-6. 문서 파일명은 영문 소문자와 하이픈을 기본으로 하며 날짜 또는 버전을 포함한다.
-7. 실제 개발에 반영된 문서는 Git commit history와 Issues/PR로 변경 이력을 남긴다.
-8. 중요한 방향 변경은 `DECISIONS.md`에 기록한다.
+4. 새 Claude 계정/세션은 추가로 `CLAUDE_DEVELOPER_BOOTSTRAP.md`를 읽고 필요 시 `CLAUDE_SECONDARY_START_PROMPT.md`를 사용한다.
+5. ChatGPT 기획이 개발로 넘어갈 때는 Handoff Issue와 사용자 승인 Gate를 사용한다.
+6. 여러 Claude를 병렬로 사용할 때는 한 Issue = 한 실행 Claude, 한 작업 = 전용 branch를 기본으로 한다.
+7. Markdown을 기본 관리 포맷으로 사용한다.
+8. 문서 파일명은 영문 소문자와 하이픈을 기본으로 하며 날짜 또는 버전을 포함한다.
+9. 실제 개발에 반영된 문서는 Git commit history와 Issues/PR로 변경 이력을 남긴다.
+10. 중요한 방향 변경은 `DECISIONS.md`에 기록한다.
 
 ## 이관 메모
 


### PR DESCRIPTION
## 목적
새 Claude 계정/Project/Code 세션이 기존 Claude와 동일한 개발자 역할을 GitHub 기준으로 자동 복원할 수 있도록 부트스트랩 문서를 공통 시작 규칙에 연결합니다.

## 변경
- `CLAUDE.md` 시작 순서에 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md` 추가
- `docs/CLAUDE_SECONDARY_START_PROMPT.md` 사용 규칙 추가
- 여러 Claude 병렬 작업 규칙: 한 Issue = 한 실행 Claude, 한 작업 = 전용 branch
- `AGENTS.md`에 동일한 공통 규칙 반영
- `docs/INDEX.md`에 부트스트랩 문서 2종 등록

## 충돌 방지
현재 기존 Claude가 진행 중인 Issue/branch는 그대로 두고, 새 Claude는 다른 Issue/branch를 담당하도록 명시합니다.