### PR TITLE
Add Google Drive deploy ZIP handoff workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 5. 코드 작업이라면 관련 PR/최근 변경사항
 
 Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`를 읽고, 필요 시 `docs/CLAUDE_SECONDARY_START_PROMPT.md`를 시작 프롬프트로 사용한다.
+개발·테스트 완료 후 배포 인수인계가 필요한 작업은 `docs/DEPLOYMENT_HANDOFF.md`를 따른다.
 
 대화 기억만으로 현재 상태를 추정하지 않는다.
 
@@ -62,6 +63,7 @@ Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`�
 - ChatGPT→Claude 인수인계: `docs/CHATGPT_CLAUDE_HANDOFF.md`
 - Claude 계정/세션 복원: `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`
 - 2차 Claude 시작 프롬프트: `docs/CLAUDE_SECONDARY_START_PROMPT.md`
+- 배포 ZIP 인수인계: `docs/DEPLOYMENT_HANDOFF.md`
 - 작품 콘텐츠 기획: `docs/content/`
 - 기능 기획: `docs/product/`
 - QA: `docs/qa/`
@@ -73,10 +75,18 @@ Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`�
 작업 완료 시 최소한 다음을 확인한다.
 - 관련 Issue 상태 갱신
 - 결과물 경로 또는 PR 연결
+- 배포 대기 작업이면 ZIP/Drive 인수인계 정보 기록
 - 프로젝트 전체 상태에 영향을 주면 `docs/PROJECT_STATE.md` 갱신
 - 중요한 방향 변경이면 `docs/DECISIONS.md` 기록
 
-## 9. 그곳지금 콘텐츠 원칙
+## 9. 배포 인수인계 원칙
+- 개발 소스 기준본은 GitHub다.
+- 배포 ZIP은 전달/보관용이며 GitHub 상태를 대체하지 않는다.
+- 개발·테스트 완료 후 필요하면 배포 ZIP을 생성하고 `docs/DEPLOYMENT_HANDOFF.md` 규칙에 따라 Google Drive `그곳지금/Deploy/READY`에 보관한다.
+- Drive 업로드 권한이 없는 개발자는 ZIP 파일명/경로와 테스트 결과를 남기고 사용자의 업로드를 기다린다.
+- 사용자가 실제 운영 배포하기 전에는 `DEPLOYED`로 표시하지 않는다.
+
+## 10. 그곳지금 콘텐츠 원칙
 - K-콘텐츠의 실제 장소와 여행 경험을 연결한다.
 - 일반 사용자 글은 설명서보다 친구가 알려주는 듯한 자연스러운 20~30대 톤을 우선한다.
 - 과도한 정보 나열을 피하고, 작품 속 장면·장소·숨은 이야기·의외성 있는 정보의 연결을 중시한다.
@@ -100,7 +110,7 @@ Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`�
 - 핵심 목표치 축소, 언어 정책, 대규모 데이터 구조, 승인 Gate 등 큰 방향 변경은 사용자에게 먼저 알린다.
 - 스킬 변경 시 `CHANGELOG.md`에 이유와 변경내용을 기록한다.
 
-## 10. AI별 기본 역할
+## 11. AI별 기본 역할
 역할은 고정하지 않되 기본적으로 다음을 우선한다.
 - ChatGPT: 기획, 조사, 콘텐츠, SEO/UX, 요구사항 정의, 프로젝트 정리, 사용자 의사결정 지원
 - Claude: 저장소 분석, 기술검토, 개발, 리팩터링, 테스트, 디버깅
@@ -108,7 +118,7 @@ Claude 새 계정/새 세션은 추가로 `docs/CLAUDE_DEVELOPER_BOOTSTRAP.md`�
 
 핵심은 역할 구분이 아니라 **모든 결과가 GitHub에 다시 남는 것**이다.
 
-## 11. 완료 정의
+## 12. 완료 정의
 `Done`은 단순히 "작성함"이 아니다. 가능한 경우 아래를 충족해야 한다.
 - 요구사항 충족
 - 결과물 저장

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ Claude는 작업 시작 시 반드시 다음을 읽는다.
 3. `docs/PROJECT_STATE.md`
 4. `docs/ROADMAP.md`
 5. `docs/CHATGPT_CLAUDE_HANDOFF.md`
-6. 관련 GitHub Issue
-7. 연결된 기획문서
-8. 관련 코드/최근 PR
+6. `docs/DEPLOYMENT_HANDOFF.md`
+7. 관련 GitHub Issue
+8. 연결된 기획문서
+9. 관련 코드/최근 PR
 
 새 Claude 계정/새 Claude Project/새 Claude Code 세션에서 시작할 때는 `docs/CLAUDE_SECONDARY_START_PROMPT.md`를 최초 시작 프롬프트로 사용할 수 있다.
 
@@ -111,6 +112,18 @@ Claude는 기획안이 위 스킬의 핵심 기준과 명백히 충돌하면 그
 - 장소 연계 퀴즈의 상태 유지
 - 다국어 전환
 - 기획안과 다른 구현이 있다면 이유
+
+## 배포 ZIP 인수인계
+개발·테스트가 끝난 작업은 `docs/DEPLOYMENT_HANDOFF.md`를 따른다.
+
+기본 규칙:
+- 소스 기준본은 GitHub다. ZIP만 수정하고 GitHub에 반영하지 않는다.
+- 배포 가능한 ZIP을 만든다.
+- 파일명에 날짜와 Issue 번호를 포함한다.
+- Google Drive 접근 권한이 있으면 `그곳지금/Deploy/READY`에 업로드한다.
+- Drive 업로드가 불가능하면 정확한 ZIP 파일명과 로컬 경로를 보고한다.
+- Issue/PR에 `READY TO DEPLOY`, commit/PR, ZIP 이름, Drive 링크 또는 로컬 경로, 테스트 결과, 남은 위험을 기록한다.
+- 사용자가 실제 배포하기 전에는 `DEPLOYED`라고 표시하지 않는다.
 
 ## 스킬 지속개선
 반복되는 콘텐츠 개발 문제나 공통 개선점을 발견하면 `skills/geogotjigeum-content/SKILL.md`의 지속개선 규칙을 따른다. 기존 방향을 강화하는 세부 체크리스트는 스킬 업데이트 후보로 기록하고, 큰 정책 변경은 사용자에게 먼저 알린다.

--- a/docs/DEPLOYMENT_HANDOFF.md
+++ b/docs/DEPLOYMENT_HANDOFF.md
@@ -1,0 +1,70 @@
+# 배포 ZIP 인수인계 규칙
+
+## 목적
+개발이 로컬 PC 밖에서 끝나더라도 사용자가 외부/퇴근 후 다른 기기에서 배포할 수 있도록, 배포 가능한 ZIP을 Google Drive의 공용 위치에 보관한다.
+
+GitHub는 코드·문서·Issue·PR의 Single Source of Truth이고, Google Drive는 **배포용 완성 ZIP 전달/보관 용도**로만 사용한다.
+
+## Google Drive 배포 폴더
+- 루트: `그곳지금/Deploy`
+- READY: https://drive.google.com/drive/folders/10XRQsnxTJI9DRsm5LO1G4YTWK2w684AT
+- ARCHIVE: https://drive.google.com/drive/folders/14rU_DS4amrRsrAxRfwzAgTnAL3MxK4gp
+
+### READY
+현재 배포 가능한 최신 ZIP을 둔다.
+
+권장 파일명:
+`geugotjigeum_YYYY-MM-DD_issue-N.zip`
+
+예:
+`geugotjigeum_2026-08-27_issue-10.zip`
+
+가능하면 최신 배포본을 쉽게 찾도록 `CURRENT.zip` 이름의 복사본/최신본도 유지한다.
+
+### ARCHIVE
+이전 배포본을 보관한다. 새 ZIP이 READY에 올라가고 정상 배포가 끝나면 이전 배포본을 ARCHIVE로 이동한다.
+
+## Claude 개발 완료 시 필수 인수인계
+개발·테스트가 끝나면 다음 순서로 처리한다.
+
+1. 최신 `main` 또는 승인된 branch 상태를 확인한다.
+2. 배포 가능한 사이트 디렉터리/ZIP을 생성한다.
+3. ZIP 이름에 날짜와 Issue 번호를 포함한다.
+4. Google Drive 접근/업로드 권한이 있으면 `Deploy/READY`에 ZIP을 업로드한다.
+5. Google Drive 업로드가 불가능하면 ZIP을 생성한 로컬 경로와 정확한 파일명을 보고하고, 사용자가 업로드할 수 있도록 멈춘다.
+6. 관련 GitHub Issue 또는 PR에 아래를 기록한다.
+   - 상태: `READY TO DEPLOY`
+   - Issue 번호
+   - commit SHA / PR
+   - 배포 ZIP 파일명
+   - Drive 링크 또는 로컬 파일 경로
+   - 테스트 결과
+   - 알려진 위험/주의사항
+7. 사용자가 실제 배포를 완료하기 전에는 `DEPLOYED`로 표시하지 않는다.
+
+## Issue/PR 보고 예시
+
+```text
+READY TO DEPLOY
+- Issue: #10
+- Commit/PR: <sha or PR link>
+- Deploy ZIP: geugotjigeum_2026-08-27_issue-10.zip
+- Drive READY: <link>
+- Test: PASS
+- Known risks: 없음
+- Production deploy: NOT YET
+```
+
+## 중요한 원칙
+- 배포 ZIP은 개발 소스의 기준본이 아니다. 소스의 기준본은 GitHub다.
+- ZIP만 수정하고 GitHub에 반영하지 않는 작업은 금지한다.
+- 운영 배포 전에 PR/승인 절차를 우선한다.
+- 다른 Claude의 진행 중 branch를 덮어쓰지 않는다.
+- ZIP 생성 과정에서 API key, secret, 개인 로컬 설정 파일이 포함되지 않았는지 확인한다.
+
+## 향후 자동화
+수동 흐름이 안정되면 다음 순서로 자동화한다.
+
+`PR merge → 배포 ZIP 자동 생성 → Drive/Artifact 저장 → 사용자 승인/배포`
+
+최종적으로는 `main merge → 자동 deploy`로 전환하여 ZIP 수동 배포 자체를 없애는 것을 목표로 한다.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,6 +19,9 @@
 - [`CLAUDE_SECONDARY_START_PROMPT.md`](CLAUDE_SECONDARY_START_PROMPT.md)  
   2차 Claude 계정·Project·Code 세션에 그대로 붙여 넣는 시작 프롬프트.
 
+- [`DEPLOYMENT_HANDOFF.md`](DEPLOYMENT_HANDOFF.md)  
+  개발 완료 후 배포 ZIP을 Google Drive `그곳지금/Deploy/READY`로 인수인계하고 Issue/PR에 `READY TO DEPLOY` 상태를 남기는 운영 규칙.
+
 - [`ROADMAP.md`](ROADMAP.md)  
   AI 공동개발 기반 구축부터 Inbox·자동보고·멀티에이전트 고도화까지의 단계별 로드맵.
 
@@ -83,10 +86,11 @@ docs/
 4. 새 Claude 계정/세션은 추가로 `CLAUDE_DEVELOPER_BOOTSTRAP.md`를 읽고 필요 시 `CLAUDE_SECONDARY_START_PROMPT.md`를 사용한다.
 5. ChatGPT 기획이 개발로 넘어갈 때는 Handoff Issue와 사용자 승인 Gate를 사용한다.
 6. 여러 Claude를 병렬로 사용할 때는 한 Issue = 한 실행 Claude, 한 작업 = 전용 branch를 기본으로 한다.
-7. Markdown을 기본 관리 포맷으로 사용한다.
-8. 문서 파일명은 영문 소문자와 하이픈을 기본으로 하며 날짜 또는 버전을 포함한다.
-9. 실제 개발에 반영된 문서는 Git commit history와 Issues/PR로 변경 이력을 남긴다.
-10. 중요한 방향 변경은 `DECISIONS.md`에 기록한다.
+7. 개발 완료 후 외부/다른 기기에서 수동 배포가 필요하면 `DEPLOYMENT_HANDOFF.md`에 따라 배포 ZIP을 Drive에 보관한다.
+8. Markdown을 기본 관리 포맷으로 사용한다.
+9. 문서 파일명은 영문 소문자와 하이픈을 기본으로 하며 날짜 또는 버전을 포함한다.
+10. 실제 개발에 반영된 문서는 Git commit history와 Issues/PR로 변경 이력을 남긴다.
+11. 중요한 방향 변경은 `DECISIONS.md`에 기록한다.
 
 ## 이관 메모
 


### PR DESCRIPTION
## 목적
개발이 외부/퇴근 후 완료돼도 로컬 PC 없이 배포 ZIP을 전달받을 수 있도록 Google Drive 기반 배포 인수인계 규칙을 추가합니다.

## 변경
- Google Drive `그곳지금/Deploy/READY`, `ARCHIVE` 폴더 생성
- `docs/DEPLOYMENT_HANDOFF.md` 추가
- `CLAUDE.md`에 개발 완료 후 ZIP 생성·Drive 업로드·Issue/PR `READY TO DEPLOY` 기록 규칙 추가
- `AGENTS.md` 공통 운영 규칙에 배포 인수인계 반영
- `docs/INDEX.md`에 배포 문서 등록

## 운영 원칙
GitHub는 소스 기준본이고 Google Drive는 배포용 ZIP 전달/보관만 담당합니다. Claude에 Drive 업로드 권한이 없을 경우 ZIP 파일명/로컬 경로까지 보고하고 사용자가 업로드합니다.