### PR TITLE
Issue #19: 홈페이지 리디자인 A(Cinematic Content Discovery) 구현

### DIFF
--- a/site/contentmap_app.js
+++ b/site/contentmap_app.js
@@ -244,7 +244,12 @@ const UI_STRINGS = {
     heroNearbyBtn:"내주변여행",
     heroSearchBtn:"여행지찾기",
     homeIconLabel:"홈",
-    heroTodayPickLabel:"오늘의 장소"
+    heroTodayPickLabel:"오늘의 장소",
+    // 2026-08 Issue #19 홈페이지 리디자인 A: 히어로 1차 CTA·발견 섹션 타이틀·featured scene 키커
+    heroPrimaryCta:"작품 발견하기",
+    discoverySectionTitle:"지금, 발견해보세요",
+    discoverySectionSubtitle:"이 장면을 좋아했다면, 그 장소도 좋아하게 될 거예요.",
+    heroFeatureKicker:"장면 → 실제 장소"
   },
   en: {
     headerTagline:"Real places behind the stories you love — pick a story, then click the map.",
@@ -412,7 +417,11 @@ const UI_STRINGS = {
     heroNearbyBtn:"Near me now",
     heroSearchBtn:"Find a trip",
     homeIconLabel:"Home",
-    heroTodayPickLabel:"Today's pick"
+    heroTodayPickLabel:"Today's pick",
+    heroPrimaryCta:"Discover Stories",
+    discoverySectionTitle:"Discover Now",
+    discoverySectionSubtitle:"If you loved the scene, you'll love the place.",
+    heroFeatureKicker:"Scene → Real Place"
   },
   // 2026-08 2단계 4-2: 일본어 UI 사전 — ko 사전과 1:1 동일한 키 구성.
   // 표기 원칙: 성지순례 팬덤에서 통용되는 어휘(聖地巡礼·ロケ地)를 쓰고, 존댓말(です·ます)로 통일.
@@ -582,7 +591,11 @@ const UI_STRINGS = {
     heroNearbyBtn:"近くを旅する",
     heroSearchBtn:"旅先を探す",
     homeIconLabel:"ホーム",
-    heroTodayPickLabel:"今日のおすすめ"
+    heroTodayPickLabel:"今日のおすすめ",
+    heroPrimaryCta:"作品を発見する",
+    discoverySectionTitle:"今すぐ発見",
+    discoverySectionSubtitle:"そのシーンが好きなら、その場所もきっと好きになる。",
+    heroFeatureKicker:"シーン → 実在の場所"
   },
   // 2026-08 3단계: 번체 중문(대만·홍콩 대상) UI 사전 — ko 사전과 1:1 동일한 키 구성.
   // GSC 분석 결과 구글 검색이 그대로 통하는 번체(대만·홍콩)를 먼저 서비스하기로 결정
@@ -752,7 +765,11 @@ const UI_STRINGS = {
     heroNearbyBtn:"附近旅行",
     heroSearchBtn:"尋找旅遊地",
     homeIconLabel:"首頁",
-    heroTodayPickLabel:"今日推薦地點"
+    heroTodayPickLabel:"今日推薦地點",
+    heroPrimaryCta:"探索作品",
+    discoverySectionTitle:"現在就探索",
+    discoverySectionSubtitle:"如果你喜歡這個畫面，你也會喜歡這個地方。",
+    heroFeatureKicker:"畫面 → 真實地點"
   }
 };
 function t(key){
@@ -1594,6 +1611,13 @@ function renderLandingCopy(){
   if (kicker) kicker.textContent = t('landingKicker');
   if (headline) headline.textContent = t('landingHeadline');
   if (blurb) blurb.innerHTML = t('landingBlurb');
+  // 2026-08 Issue #19 홈페이지 리디자인 A: 신규 1차 CTA·발견 섹션 타이틀도 언어 전환마다 갱신
+  const primaryCtaText = document.getElementById('heroPrimaryCtaText');
+  const discTitle = document.getElementById('discoverySectionTitle');
+  const discSub = document.getElementById('discoverySectionSubtitle');
+  if (primaryCtaText) primaryCtaText.textContent = t('heroPrimaryCta');
+  if (discTitle) discTitle.textContent = t('discoverySectionTitle');
+  if (discSub) discSub.textContent = t('discoverySectionSubtitle');
 }
 // 2026-08 UI 개편(랜딩 히어로 재설계) — "기능은 많은데 여행 욕구는 약하다"는 기획 피드백에
 // 따라, 히어로 영역 배경을 실제 작품 대표 이미지 콜라주로 채운다. 이미 카드에 쓰이고 있는
@@ -1634,6 +1658,8 @@ function renderHeroTodayPick(){
   const titleEl = document.getElementById('heroTodayPickTitle');
   const hookEl = document.getElementById('heroTodayPickHook');
   if (imgEl) imgEl.style.backgroundImage = "url('" + work.heroImage.url.replace(/'/g, "\\'") + "')";
+  const kickerEl = document.getElementById('heroFeatureKicker');
+  if (kickerEl) kickerEl.textContent = t('heroFeatureKicker');
   if (labelEl) labelEl.textContent = t('heroTodayPickLabel');
   if (titleEl) titleEl.textContent = tField(work, 'title');
   if (hookEl) hookEl.textContent = tField(work, 'hookTagline');
@@ -1643,6 +1669,15 @@ function renderHeroTodayPick(){
 }
 window.pickTodayWork = pickTodayWork;
 window.renderHeroTodayPick = renderHeroTodayPick;
+
+// 2026-08 Issue #19 홈페이지 리디자인 A: 히어로 1차 CTA — 페이지 이동 없이 발견 섹션(작품
+// 카드 목록)으로 부드럽게 스크롤한다. 이미 렌더돼 있는 기존 #landingCards를 그대로 가리킬 뿐,
+// 새 데이터/라우팅을 추가하지 않는다.
+function scrollToDiscovery(){
+  const target = document.getElementById('discoverySection') || document.getElementById('landingCards');
+  if (target && target.scrollIntoView) target.scrollIntoView({ behavior:'smooth', block:'start' });
+}
+window.scrollToDiscovery = scrollToDiscovery;
 
 function renderLandingCards(){
   renderRegionRow();

--- a/site/contentmap_style.css
+++ b/site/contentmap_style.css
@@ -13,9 +13,10 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Apple SD 
 #app{display:flex;flex-direction:column;height:100vh;height:100dvh;}
 
 header{
-  padding:14px 20px;border-bottom:1px solid var(--border);
+  padding:17px 24px;border-bottom:1px solid var(--border);
   display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;
   background:linear-gradient(180deg,#171a21,#12141a);
+  min-height:72px;
 }
 header h1{font-size:17px;margin:0;font-weight:700;letter-spacing:.2px;}
 header p{margin:2px 0 0;color:var(--sub);font-size:12.5px;}
@@ -131,7 +132,18 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    "웹사이트 다크모드 강제" 기능 등)가 밝은 배경을 멋대로 어둡게, 어두운 글자를 밝게 뒤집어버리는
    현상을 막기 위함. 이 히어로 영역은 항상 밝은 카드로 보여야 하는 의도된 디자인이라는 걸
    브라우저에게 알려준다. */
-.landing-hero{position:relative;border-radius:24px;overflow:hidden;margin:4px 0 26px;isolation:isolate;color-scheme:light;}
+/* 2026-08 Issue #19: 홈페이지 리디자인 A(Cinematic Content Discovery, docs/design/HOMEPAGE_REDESIGN_A_V1.md).
+   기존 "밝은 히어로" 방향(task #430)을 대체하는 새 승인 방향 — 다크 시네마틱 캔버스 + 코랄 액센트.
+   전역 --accent(#e0603a, 지도 화면 등 앱 전체에서 계속 쓰임)는 건드리지 않고, 이 신규 디자인
+   토큰은 #app.landing 스코프 안에서만 정의해 홈페이지 밖으로 새어나가지 않게 한다. */
+#app.landing{
+  --ds-bg:#0A0B0F; --ds-bg-elevated:#141820; --ds-hero-left:#232A38; --ds-hero-right:#10141C;
+  --ds-accent:#FF7B57; --ds-accent-soft:#FF9B7D; --ds-text-2:#CDD2DC; --ds-text-3:#9EA5B2; --ds-line:#242A34;
+}
+.landing-hero{position:relative;border-radius:24px;overflow:hidden;margin:4px 0 26px;isolation:isolate;color-scheme:dark;background:linear-gradient(115deg,var(--ds-hero-left,#232A38),var(--ds-hero-right,#10141C));}
+/* 좌(헤드라인+CTA) : 우(featured scene 패널) 2열 — 모바일은 아래 @media(max-width:768px)에서 1열로 스택 */
+.landing-hero-grid{position:relative;z-index:2;display:grid;grid-template-columns:1.15fr .85fr;align-items:center;gap:8px;}
+.landing-hero-feature{display:flex;align-items:center;padding:24px 40px 24px 12px;min-height:1px;}
 .landing-hero-collage{position:absolute;inset:0;z-index:0;display:grid;grid-template-columns:repeat(6,1fr);grid-auto-rows:1fr;gap:2px;}
 /* 2026-08 재조정: "누르스름하고 빛바랜 사진 같다"는 피드백 — 기존엔 brightness(.92) saturate(1.05)로
    오히려 원본보다 어둡고 덜 채도있게 눌러놨었다. 실제 여행 욕구를 자극하려면 사진이 쨍하고
@@ -163,13 +175,17 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    흰색 오버레이 자체의 밝기와 헤드라인의 텍스트 그림자로 보완한다. */
 .landing-hero::before{
   content:'';position:absolute;inset:0;z-index:1;
-  background:linear-gradient(180deg,rgba(255,255,255,.42) 0%,rgba(255,255,255,.78) 45%,rgba(255,255,255,.94) 100%);
+  background:
+    linear-gradient(100deg,rgba(10,11,15,.93) 0%,rgba(10,11,15,.72) 38%,rgba(10,11,15,.38) 64%,rgba(10,11,15,.58) 100%),
+    linear-gradient(180deg,rgba(10,11,15,.2) 0%,rgba(10,11,15,.05) 35%,rgba(10,11,15,.62) 100%);
 }
-.landing-hero-content{position:relative;z-index:2;padding:52px 24px 36px;}
+.landing-hero-content{position:relative;z-index:2;padding:52px 16px 36px 44px;}
+.landing-kicker{color:var(--ds-accent,var(--accent2));font-size:12px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;margin-bottom:12px;}
+.landing-kicker:empty{display:none;}
 /* 2026-08 재조정: 헤드라인이 본문과 비슷한 톤(짙은 남색)이라 눈에 덜 띈다는 피드백 —
    사이트 전체에서 강조색으로 이미 쓰고 있는 --accent(주황빛 테라코타)로 바꿔 카운터 배너·버튼
    호버 등과 같은 색 언어를 유지하면서도 헤드라인이 히어로에서 확실히 도드라지게 했다. */
-.landing-hero-content h2{margin:0 0 20px;font-size:30px;font-weight:800;color:var(--accent);letter-spacing:-.01em;line-height:1.4;text-shadow:0 1px 18px rgba(255,255,255,.7),0 1px 2px rgba(255,255,255,.6);}
+.landing-hero-content h2{margin:0 0 20px;font-size:30px;font-weight:800;color:#fff;letter-spacing:-.01em;line-height:1.4;text-shadow:0 2px 20px rgba(0,0,0,.5),0 1px 3px rgba(0,0,0,.6);}
 /* 2026-08 히어로 주목도 개선 #2: 헤드라인이 페이지 첫 로드 시 한 번 슬라이드업+페이드인 — 카운터
    배너(매번 재생)와 달리, 이건 최초 페인트 때 딱 한 번만 자연스럽게 재생되는 연출이라 CSS
    애니메이션만으로 충분하고 별도 JS 트리거가 필요 없다. */
@@ -190,15 +206,26 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    ("이건 뭐지?" 하는 호기심을 유도하는 게 의도) — 눌러야 내용이 드러난다.
    지역별 여행: #heroRegionPanel을 펼쳐 기존 지역칩을 그대로 보여줌.
    내주변여행 / 여행지찾기: 기존 '내 주변 콘텐츠 투어' 모달을 열되, 후자는 주소 검색이 바로 펼쳐진 채로 연다. */
-.landing-hero-actions{display:flex;justify-content:center;flex-wrap:wrap;gap:10px;margin-top:22px;}
+.landing-hero-cta-row{display:flex;justify-content:flex-start;margin-top:22px;}
+/* 1차 CTA("작품 발견하기") — 코랄 필 버튼. #app.landing 안에서만 렌더되는 버튼이라
+   var(--ds-accent) 우선, 혹시 모를 스코프 누락 상황을 대비해 var(--accent2)로 폴백. */
+.hero-primary-cta{
+  display:inline-flex;align-items:center;gap:8px;
+  background:var(--ds-accent,var(--accent2));color:#fff;border:none;border-radius:999px;
+  padding:14px 26px;font-size:15px;font-weight:800;font-family:inherit;cursor:pointer;
+  box-shadow:0 10px 24px rgba(255,123,87,.32);transition:.15s;min-height:44px;
+}
+.hero-primary-cta:hover{background:var(--ds-accent-soft,#ea7250);transform:translateY(-1px);box-shadow:0 14px 30px rgba(255,123,87,.4);}
+.hero-primary-cta:focus-visible{outline:2px solid #fff;outline-offset:3px;}
+.landing-hero-actions{display:flex;justify-content:flex-start;flex-wrap:wrap;gap:10px;margin-top:12px;}
 .hero-action-btn{
   display:inline-flex;align-items:center;gap:7px;background:#1a1c22;color:#fff;
   border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:11px 20px;
   font-size:13.5px;font-weight:700;font-family:inherit;cursor:pointer;transition:.12s;
   box-shadow:0 6px 16px rgba(0,0,0,.18);
 }
-.hero-action-btn:hover{border-color:var(--accent2);background:#22252e;}
-.hero-action-btn.active{background:var(--accent2);border-color:var(--accent2);}
+.hero-action-btn:hover{border-color:var(--ds-accent,var(--accent2));background:#22252e;}
+.hero-action-btn.active{background:var(--ds-accent,var(--accent2));border-color:var(--ds-accent,var(--accent2));}
 
 /* 히어로 바로 아래, 카드 위에 나타나는 "지역별 여행" 펼침 패널 — 기존 지역칩(.region-row-wrap)을
    그대로 감싸고, 배경만 살짝 얹어 히어로에서 이어지는 하나의 동작처럼 보이게 한다. */
@@ -212,22 +239,26 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    달라지는 요소를 심어 재방문 유인을 준다. 날짜 기반으로 결정론적으로 골라, "오늘의"라는
    표현이 항상 사실이 되도록 함(pickTodayWork() 참고). 클릭하면 바로 그 작품의 인터랙티브
    지도로 진입(enterWork). 히어로 안 다른 버튼들과 같은 어두운 필 톤을 따라간다. */
+/* 2026-08 Issue #19: 오늘의 장소 카드를 히어로 우측 "featured scene panel"로 승격.
+   scene → work → 실제 장소 관계를 그대로 보여주는 기존 컴포넌트를 재사용(신규 데이터 없음),
+   .landing-hero-feature 안에서 더 크게 렌더되도록 치수만 키웠다. */
 .hero-today-pick{
-  display:flex;align-items:center;gap:12px;width:100%;max-width:420px;margin:16px auto 0;
-  background:#1a1c22;border:1px solid rgba(255,255,255,.12);border-radius:16px;
-  padding:9px 16px 9px 9px;cursor:pointer;text-align:left;font-family:inherit;
-  transition:.15s;box-shadow:0 6px 16px rgba(0,0,0,.18);
+  display:flex;flex-direction:column;gap:10px;width:100%;margin:0;
+  background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.14);border-radius:18px;
+  padding:16px;cursor:pointer;text-align:left;font-family:inherit;
+  transition:.15s;box-shadow:0 12px 32px rgba(0,0,0,.35);backdrop-filter:blur(6px);
 }
-.hero-today-pick:hover{border-color:var(--accent2);background:#22252e;}
+.hero-today-pick:hover{border-color:var(--ds-accent,var(--accent2));background:rgba(255,255,255,.1);}
 .hero-today-pick[hidden]{display:none;}
 .hero-today-pick-img{
-  width:50px;height:50px;flex:0 0 50px;border-radius:12px;background-size:cover;
+  width:100%;height:150px;border-radius:12px;background-size:cover;
   background-position:center;background-color:#333;
 }
-.hero-today-pick-text{display:flex;flex-direction:column;gap:2px;min-width:0;}
-.hero-today-pick-label{font-size:10px;font-weight:800;color:var(--card-accent);text-transform:uppercase;letter-spacing:.05em;}
-.hero-today-pick-title{font-size:13.5px;font-weight:800;color:#fff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.hero-today-pick-hook{font-size:11.5px;color:rgba(255,255,255,.72);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.hero-today-pick-text{display:flex;flex-direction:column;gap:3px;min-width:0;}
+.hero-today-pick-kicker{font-size:10.5px;font-weight:800;color:var(--ds-text-2,#cdd2dc);text-transform:uppercase;letter-spacing:.08em;opacity:.85;}
+.hero-today-pick-label{font-size:10.5px;font-weight:800;color:var(--ds-accent,var(--card-accent));text-transform:uppercase;letter-spacing:.05em;margin-top:2px;}
+.hero-today-pick-title{font-size:16px;font-weight:800;color:#fff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.hero-today-pick-hook{font-size:12.5px;color:rgba(255,255,255,.78);line-height:1.5;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;white-space:normal;}
 
 /* 2026-08 신규: 랜딩 상단 동적 카운터 배너(task #384) — 인물/이야기/장소 규모를 한눈에 보여주고,
    장소 수는 진입할 때마다 카운트업 애니메이션으로 주목을 끈다.
@@ -303,6 +334,13 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 .region-chip-country{border-style:dashed;margin-left:4px;}
 .region-chip-country:first-of-type{margin-left:10px;}
 .region-chip-country.active{background:var(--accent);border-color:var(--accent);border-style:solid;}
+/* 2026-08 Issue #19: 발견 섹션 타이틀 — heroPrimaryCta(scrollToDiscovery())의 스크롤 목적지.
+   히어로 밖(일반 다크 배경) 영역이라 전역 --text/--sub 토큰을 그대로 쓴다. */
+.discovery-section-head{max-width:820px;margin:36px auto 18px;text-align:center;}
+.discovery-section-head h3{margin:0 0 8px;font-size:22px;font-weight:800;color:var(--text);}
+.discovery-section-head h3:empty{display:none;}
+.discovery-section-head p{margin:0;font-size:13.5px;color:var(--sub);line-height:1.6;}
+.discovery-section-head p:empty{display:none;}
 .landing-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;text-align:left;}
 .landing-footer{margin-top:28px;text-align:center;font-size:12px;color:var(--sub);}
 .landing-footer a{color:var(--sub);text-decoration:underline;margin:0 8px;}
@@ -1079,6 +1117,8 @@ details.course-btn > div .course-btn{margin:0;}
   /* 2026-08 UI 개편(task #431 모바일 재설계): 히어로 콜라주는 칸 수를 줄이고 안쪽 여백도
      좁혀서 헤드라인·카운터 배너·검색창이 화면에 더 빨리(스크롤 없이 가깝게) 보이도록 한다. */
   .landing-hero{border-radius:16px;margin:0 0 18px;}
+  .landing-hero-grid{grid-template-columns:1fr;gap:0;}
+  .landing-hero-feature{padding:0 16px 22px;}
   .landing-hero-collage{grid-template-columns:repeat(3,1fr);}
   /* 2026-08 9라운드 재조정: 위 "타일 하나가 커서 어두워 보인다"는 가정으로 오버레이를 거의
      불투명한 흰색(86~97%)까지 올려놨었는데, 그 결과 정작 사진 자체가 거의 안 보일 정도로
@@ -1087,17 +1127,22 @@ details.course-btn > div .course-btn{margin:0;}
      밝기·채도를 desktop 수준으로 올려서, 사진이 실제로 화면에 드러나며 여행 욕구를 자극하도록
      되돌렸다. 헤드라인 가독성은 기존 텍스트 그림자(h2의 text-shadow)로 계속 보완된다. */
   .landing-hero::before{
-    background:linear-gradient(180deg,rgba(255,255,255,.4) 0%,rgba(255,255,255,.7) 45%,rgba(255,255,255,.9) 100%);
+    background:
+      linear-gradient(180deg,rgba(10,11,15,.55) 0%,rgba(10,11,15,.3) 30%,rgba(10,11,15,.72) 100%);
   }
-  .hero-collage-tile{filter:brightness(1.12) saturate(1.45) contrast(1.08);}
-  .landing-hero-content{padding:28px 16px 24px;}
+  .hero-collage-tile{filter:brightness(1.05) saturate(1.3) contrast(1.05);}
+  .landing-hero-content{padding:28px 16px 20px;}
   .landing-hero-content h2{font-size:21px;margin:0 0 14px;}
-  .landing-hero-actions{margin-top:16px;gap:8px;}
-  .hero-action-btn{padding:9px 15px;font-size:12.5px;}
-  .hero-today-pick{max-width:100%;margin:12px 0 0;padding:8px 12px 8px 8px;}
-  .hero-today-pick-img{width:42px;height:42px;flex:0 0 42px;}
-  .hero-today-pick-title{font-size:12.5px;}
-  .hero-today-pick-hook{font-size:11px;}
+  .landing-hero-cta-row{margin-top:16px;}
+  .hero-primary-cta{width:100%;justify-content:center;padding:14px 18px;font-size:14px;}
+  .landing-hero-actions{margin-top:10px;gap:8px;}
+  .hero-action-btn{padding:9px 15px;font-size:12.5px;min-height:44px;}
+  .hero-today-pick{padding:12px;gap:8px;}
+  .hero-today-pick-img{height:120px;}
+  .hero-today-pick-title{font-size:14.5px;}
+  .hero-today-pick-hook{font-size:12px;}
+  .discovery-section-head{margin:26px auto 12px;padding:0 4px;}
+  .discovery-section-head h3{font-size:19px;}
   .hero-region-panel{padding:14px 14px 8px;margin:0 0 18px;}
   /* 화살표 버튼은 데스크톱에서만 보여주고, 모바일은 터치 스와이프가 더 자연스러워서
      화살표 없이 페이드 힌트만 남긴다(엄지로 스와이프할 공간을 화살표가 가리지 않도록). */

--- a/site/index.html
+++ b/site/index.html
@@ -154,23 +154,35 @@
     <div class="landing-inner">
       <div class="landing-hero" id="landingHero">
         <div class="landing-hero-collage" id="landingHeroCollage" aria-hidden="true"></div>
-        <div class="landing-hero-content">
-          <h2 id="landingHeadline">대한민국 대표 콘텐츠 여행 사이트, 그곳 지금</h2>
-          <div id="landingCounterBanner" class="landing-counter-banner" aria-live="polite"></div>
-          <div id="landingFilterWrap" class="landing-filter-hero"></div>
-          <div class="landing-hero-actions" id="landingHeroActions">
-            <button type="button" class="hero-action-btn" id="heroRegionBtn" onclick="toggleHeroPanel('region')">🗺️ <span id="heroRegionBtnText">지역별 여행</span></button>
-            <button type="button" class="hero-action-btn" id="heroNearbyBtn" onclick="openNearbyModal()">📍 <span id="heroNearbyBtnText">내주변여행</span></button>
-            <button type="button" class="hero-action-btn" id="heroSearchBtn" onclick="openNearbyModal({addressMode:true})">🔍 <span id="heroSearchBtnText">여행지찾기</span></button>
-          </div>
-          <button type="button" class="hero-today-pick" id="heroTodayPick" hidden>
-            <div class="hero-today-pick-img" id="heroTodayPickImg"></div>
-            <div class="hero-today-pick-text">
-              <span class="hero-today-pick-label" id="heroTodayPickLabel">오늘의 장소</span>
-              <span class="hero-today-pick-title" id="heroTodayPickTitle"></span>
-              <span class="hero-today-pick-hook" id="heroTodayPickHook"></span>
+        <!-- 2026-08 Issue #19: 홈페이지 리디자인 A(Cinematic Content Discovery) — 히어로를
+             좌(헤드라인+CTA)/우(오늘의 장소=featured scene panel) 2열 그리드로 재구성.
+             기존 요소는 id 그대로 재사용(JS 변경 없음), 배치만 바뀐다. -->
+        <div class="landing-hero-grid">
+          <div class="landing-hero-content">
+            <div class="landing-kicker" id="landingKicker"></div>
+            <h2 id="landingHeadline">대한민국 대표 콘텐츠 여행 사이트, 그곳 지금</h2>
+            <div id="landingCounterBanner" class="landing-counter-banner" aria-live="polite"></div>
+            <div id="landingFilterWrap" class="landing-filter-hero"></div>
+            <div class="landing-hero-cta-row">
+              <button type="button" class="hero-primary-cta" id="heroPrimaryCta" onclick="scrollToDiscovery()">🎬 <span id="heroPrimaryCtaText">작품 발견하기</span></button>
             </div>
-          </button>
+            <div class="landing-hero-actions" id="landingHeroActions">
+              <button type="button" class="hero-action-btn" id="heroRegionBtn" onclick="toggleHeroPanel('region')">🗺️ <span id="heroRegionBtnText">지역별 여행</span></button>
+              <button type="button" class="hero-action-btn" id="heroNearbyBtn" onclick="openNearbyModal()">📍 <span id="heroNearbyBtnText">내주변여행</span></button>
+              <button type="button" class="hero-action-btn" id="heroSearchBtn" onclick="openNearbyModal({addressMode:true})">🔍 <span id="heroSearchBtnText">여행지찾기</span></button>
+            </div>
+          </div>
+          <div class="landing-hero-feature">
+            <button type="button" class="hero-today-pick" id="heroTodayPick" hidden>
+              <div class="hero-today-pick-img" id="heroTodayPickImg"></div>
+              <div class="hero-today-pick-text">
+                <span class="hero-today-pick-kicker" id="heroFeatureKicker"></span>
+                <span class="hero-today-pick-label" id="heroTodayPickLabel">오늘의 장소</span>
+                <span class="hero-today-pick-title" id="heroTodayPickTitle"></span>
+                <span class="hero-today-pick-hook" id="heroTodayPickHook"></span>
+              </div>
+            </button>
+          </div>
         </div>
       </div>
       <div id="heroRegionPanel" class="hero-region-panel" hidden>
@@ -184,6 +196,11 @@
         </div>
       </div>
       <div id="landingResultCount" class="filter-result-count"></div>
+      <!-- 2026-08 Issue #19: 발견 섹션 타이틀 — scrollToDiscovery() CTA의 스크롤 목적지 -->
+      <div class="discovery-section-head" id="discoverySection">
+        <h3 id="discoverySectionTitle"></h3>
+        <p id="discoverySectionSubtitle"></p>
+      </div>
       <div class="landing-cards" id="landingCards"></div>
       <p class="landing-blurb landing-blurb-footer" id="landingBlurb">'그곳, 지금'은 제 개인 블로그입니다. 만화·영화·애니메이션을 보다가 문득 <b>"저 장면에 나온 곳은 지금 실제로 어떤 모습일까?"</b> 궁금해졌던, 지극히 개인적인 호기심에서 시작했어요. 이야기 속 장소가 사실은 지금도 갈 수 있는 진짜 여행지라는 걸 알게 되면, 그 작품을 더 오래 더 깊이 좋아하게 되더라고요. 그런 마음으로 하나씩 조사해서 채워가고 있는 저만의 기록입니다.</p>
       <div class="landing-footer"><a href="#" id="footerReportLink" onclick="openReportModal();return false;">📝 장소·인물 제안</a><a href="/regions/" id="footerRegionsLink">🗺️ 지역으로 찾기</a><a href="/places/" id="footerPlacesLink">📍 장소로 찾기</a><a href="/about/" id="footerAboutLink">서비스 소개</a><a href="/contact/" id="footerContactLink">문의</a><a href="/privacy/" id="footerPrivacyLink">개인정보처리방침</a><a href="/terms/" id="footerTermsLink">이용약관</a></div>


### PR DESCRIPTION
docs/design/HOMEPAGE_REDESIGN_A_V1.md, docs/design/DESIGN_SYSTEM_V1.md 기준 구현. 다크 시네마틱 히어로(좌 헤드라인+CTA / 우 featured scene 패널) + 신규 1차 CTA(작품 발견하기) + 발견 섹션 타이틀을 추가하고, KR/EN/JP/繁中 다국어와 기존 기능 진입점(지역별여행/내주변여행/여행지찾기/오늘의 장소)은 그대로
보존했다.

- site/index.html: .landing-hero를 .landing-hero-grid(2열)로 재구성. 기존 요소는 id 그대로 재사용(신규 마크업만 추가): landingKicker(기존에 UI_STRINGS엔 있었지만 렌더 안 되던 값 활성화), heroPrimaryCta, discoverySection/Title/Subtitle, heroFeatureKicker.
- site/contentmap_app.js: UI_STRINGS 4개 언어에 heroPrimaryCta/ discoverySectionTitle/discoverySectionSubtitle/heroFeatureKicker 키 추가. renderLandingCopy()·renderHeroTodayPick()에 새 텍스트 반영 추가, scrollToDiscovery() 신규(페이지 이동 없이 발견 섹션으로 스크롤).
- site/contentmap_style.css: #app.landing 스코프 안에서만 --ds-* 디자인 토큰 정의(전역 --accent 등 지도 화면 스타일은 그대로 둠). 히어로를 라이트→다크로 전환, 2열 그리드, 1차 CTA 버튼, featured scene 패널 확대, 발견 섹션 타이틀 스타일, 헤더 72px(데스크톱), 모바일 hero-action-btn 44px 터치타깃 보강.

QA: node --check 통과, vm 하네스로 실제 WORKS 데이터 로드 후
renderLandingCopy/renderHeroTodayPick/renderLandingCards/setLang(ko·en·ja·zh) 전부 무오류 확인. 360/390/430/1440 CSS 박스모델 계산 검증(실기기 스크린샷은 이번 세션 환경 제약으로 불가 — PR에 명시).

Preserves: KR/EN/JP/ZH i18n, 기존 진입점(works/places/map/quiz), 데이터 로딩, SEO/canonical/sitemap(무변경). Out of scope 항목(지도 아키텍처/퀴즈 로직/URL·SEO 구조/유료 서비스) 전부 미변경.

# 변경 요약

## 관련 Issue
- Closes #

## 무엇을 변경했나
- 

## 왜 변경했나
- 

## 검증
- [ ] 로컬/기능 테스트 완료
- [ ] 관련 문서 확인
- [ ] 다국어 영향 확인 (해당 시)
- [ ] SEO 영향 확인 (해당 시)

## AI/개발자 인수인계
### 완료한 것
- 

### 아직 안 한 것
- 

### 다음 한 단계
- 

### 주의사항 / 위험
- 없음

## 프로젝트 상태 반영
- [ ] 관련 Issue 업데이트
- [ ] `docs/PROJECT_STATE.md` 갱신 필요 여부 확인
- [ ] 중요한 결정이면 `docs/DECISIONS.md` 기록


Closes #19

배포: 사용자가 로컬에서 push 후 실제 운영 배포까지 완료함. 배포 ZIP은 로컬에 별도 보관(geugotjigeum_2026-08-27_issue-19.zip).