### PR TITLE
Issue #22: Map Explorer v1 — Dark Brand Shell + Bright Info PaIssue #22: Map Explorer v1 — Dark Brand Shell + Bright Info Panelnel

### DIFF
--- a/site/contentmap_app.js
+++ b/site/contentmap_app.js
@@ -76,6 +76,9 @@ let currentView = { type:'landing' };
 // 인물/장소 상세 화면의 '뒤로' 버튼이 어디로 돌아가야 하는지 기억해두는 상태.
 // (goBack/resolveReturnTarget/backBtnLabel — loadWork() 정의 바로 아래에 있음)
 let returnTarget = null;
+// Issue #22 Map Explorer v1: 현재 선택된 장소 id — 지도 위 선택 핀을 색상 외에도
+// 크기/링으로 구분하기 위해 사용 (docs/design/MAP_EXPLORER_V1.md §8, refreshLocationLayer 참고)
+let selectedLocId = null;
 
 const UI_STRINGS = {
   ko: {
@@ -1419,12 +1422,15 @@ function setupLocationLayer(){
     type:'circle',
     source:'locations',
     paint:{
-      'circle-radius':8,
+      // Issue #22 Map Explorer v1: 선택된 핀은 색만이 아니라 크기로도 구분되도록 반경을 키운다
+      // (docs/design/MAP_EXPLORER_V1.md §8 "selected pin state must be distinguishable by more
+      // than color alone"). 방문 확인(금색 테두리)과 선택 상태는 서로 다른 신호라 동시에 켜질 수 있다.
+      'circle-radius':['case', ['==', ['get','selected'], 1], 12, 8],
       'circle-color':['get','color'],
       // 방문 확인(localStorage 기반)한 장소는 금색 테두리를 더 두껍게 둘러 한눈에 구분되게 함
       // — 서버 없이도 "이미 확인한 곳/아직 안 본 곳"을 지도에서 바로 알 수 있어 완주 동기부여가 됨
-      'circle-stroke-width':['case', ['==', ['get','visited'], 1], 3, 2],
-      'circle-stroke-color':['case', ['==', ['get','visited'], 1], '#ffd23f', '#ffffff']
+      'circle-stroke-width':['case', ['==', ['get','selected'], 1], 4, ['==', ['get','visited'], 1], 3, 2],
+      'circle-stroke-color':['case', ['==', ['get','selected'], 1], '#FF7B57', ['==', ['get','visited'], 1], '#ffd23f', '#ffffff']
     }
   });
 
@@ -3220,7 +3226,8 @@ function refreshLocationLayer(work, mappableLocations){
       properties:{
         locId: loc.id, workId: work.id, color: work.pinColor,
         label: loc.nameInWork || loc.modernName,
-        visited: visited.indexOf(loc.id) !== -1 ? 1 : 0
+        visited: visited.indexOf(loc.id) !== -1 ? 1 : 0,
+        selected: loc.id === selectedLocId ? 1 : 0
       }
     };
   });
@@ -3879,6 +3886,7 @@ function showLocation(work, data, locId, isRefresh, from){
     document.getElementById('sidebar').classList.add('sidebar-detail');
     markVisited(work.id, locId);
     renderProgressBadge(work, data);
+    selectedLocId = locId;
     if (hasCoords) refreshLocationLayer(work, data.locations.filter(function(l){ return l.lat != null && l.lng != null; }));
     checkCompletion(work, data);
     if (isMobileLayout()) setMobileView('info');

--- a/site/contentmap_style.css
+++ b/site/contentmap_style.css
@@ -7,6 +7,20 @@
      문제가 있었다. 모든 카드에 같은 밝은 오렌지 하나로 통일해 항상 눈에 띄도록 함. */
   --card-accent:#ff9d42;
 }
+/* ============================================================
+   Design System V1 (docs/design/DESIGN_SYSTEM_V1.md) — promoted to :root so screens beyond
+   the homepage can reference the canonical dark/light/accent token families directly.
+   These were previously only defined locally inside #app.landing (Issue #19 homepage).
+   Issue #22 Map Explorer is the first non-homepage screen to consume them; the legacy
+   --bg/--panel/--accent/--border names above are intentionally left untouched here so the
+   already-shipped homepage/landing screen keeps rendering byte-for-byte the same. */
+:root{
+  --ds-bg:#0A0B0F; --ds-bg-elevated:#141820; --ds-hero-left:#232A38; --ds-hero-right:#10141C;
+  --ds-panel:#151923; --ds-line:#242A34; --ds-text:#FFFFFF; --ds-text-2:#CDD2DC; --ds-text-3:#9EA5B2;
+  --ds-light-bg:#F8F5EE; --ds-light-surface:#FDFBF7; --ds-light-card:#FFFFFF;
+  --ds-light-text:#1B1E24; --ds-light-text-2:#575E6B; --ds-light-line:#E1DCD2;
+  --ds-accent:#FF7B57; --ds-accent-soft:#FF9B7D;
+}
 *{box-sizing:border-box;}
 html,body{height:100%;}
 body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Apple SD Gothic Neo","Malgun Gothic",sans-serif;background:var(--bg);color:var(--text);}
@@ -49,6 +63,17 @@ header p{margin:2px 0 0;color:var(--sub);font-size:12.5px;}
    지도는 넓을수록 유용한 콘텐츠이므로 굳이 좁혀 가둘 이유가 없다 — 초광각 모니터에서 사이드바
    텍스트 줄 길이가 지나치게 늘어지는 것만 막을 수 있게 상한을 2400px로 크게 늘렸다
    (사이드바 자체에도 별도 max-width:1300px가 있어 텍스트 가독성은 그쪽에서 이미 보호됨). */
+/* ---- Issue #22 Map Explorer v1: 지도/사이드바/헤더 다크 쉘을 Design System V1으로 마이그레이션.
+   #app.landing(홈, Issue #19)은 이미 자체 --ds-* 스코프가 있으므로 건드리지 않고, 그 밖의 모든
+   화면(#app:not(.landing) — 지도, 작품 소개 탭 등)에만 새 토큰을 적용한다. 기존 --bg/--panel/
+   --border/--accent/--card-accent "변수 이름"은 그대로 두고 "값"만 이 스코프 안에서 새로 지정하므로,
+   이 파일의 기존 selector 수백 개가 var(--bg)/var(--accent)/... 를 그대로 읽는 것만으로 자동으로
+   새 팔레트를 적용받는다 — 각 selector를 일일이 고칠 필요가 없다. */
+#app:not(.landing){
+  --bg:var(--ds-bg); --panel:var(--ds-bg-elevated); --border:var(--ds-line);
+  --accent:var(--ds-accent); --card-accent:var(--ds-accent-soft);
+}
+#app:not(.landing) header{background:linear-gradient(180deg,var(--ds-bg-elevated),var(--ds-bg));}
 #main{flex:1;display:flex;min-height:0;max-width:2400px;margin:0 auto;width:100%;}
 #mapWrap{flex:1 1 auto;min-width:0;position:relative;}
 #map{width:100%;height:100%;background:#0c1620;}
@@ -60,8 +85,16 @@ header p{margin:2px 0 0;color:var(--sub);font-size:12.5px;}
    initResizer() 참고). 드래그 중에는 자바스크립트가 인라인 style.flexBasis를 직접 지정하므로
    아래 flex:0 0 42%는 '초기값'일 뿐이고, 이후에는 인라인 스타일이 우선한다. */
 #sidebar{
+  /* ---- Issue #22 Map Explorer v1: Bright Info Panel (docs/design/MAP_EXPLORER_V1.md §3/§4) ----
+     지도/헤더/모바일 탭바는 다크 브랜드 쉘로 남고, 정보 패널(사이드바 = 모바일 '정보' 탭과 동일 요소)
+     만 밝은 리딩 표면으로 뒤집는다. 아래에서 --bg/--panel/--panel2/--text/--sub/--border/--accent2를
+     이 스코프 안에서 다시 정의하면, #sidebar 하위의 기존 selector(hero-image, detail-card, 인물 카드,
+     탭, 퀴즈 등 수백 개)가 같은 변수 이름을 그대로 읽고 있으므로 전부 자동으로 밝은 팔레트를 적용받는다. */
+  --bg:var(--ds-light-bg); --panel:var(--ds-light-surface); --panel2:var(--ds-light-card);
+  --text:var(--ds-light-text); --sub:var(--ds-light-text-2); --border:var(--ds-light-line);
+  --accent2:#2f5fc4;
   flex:0 0 42%;min-width:300px;max-width:1300px;flex-shrink:0;border-left:1px solid var(--border);
-  background:var(--panel);overflow-y:auto;padding:18px;
+  background:var(--panel);color:var(--text);overflow-y:auto;padding:18px;
 }
 #sidebar.sidebar-detail{ flex-basis:42%;max-width:1300px; }
 #sidebar.resizing{transition:none !important;}
@@ -88,8 +121,8 @@ body.resizing-cursor *{user-select:none;}
 .hero-image{border-radius:12px;overflow:hidden;margin-bottom:4px;border:1px solid var(--border);}
 .hero-image img{display:block;width:100%;max-height:220px;object-fit:cover;background:#0c1620;}
 .hero-credit{background:#12141a;padding:5px 10px;}
-.hero-credit a{color:var(--sub);font-size:10.5px;text-decoration:none;}
-.hero-credit a:hover{color:var(--sub);text-decoration:underline;}
+.hero-credit a{color:#9aa4b2;font-size:10.5px;text-decoration:none;}
+.hero-credit a:hover{color:#9aa4b2;text-decoration:underline;}
 
 /* ---- 장소 실제 사진 (위키백과에서 자동으로 찾아와 상세 패널 맨 위에 크게 표시) ---- */
 .photo-hero{position:relative;background:#0c1620;min-height:140px;overflow:hidden;}
@@ -545,7 +578,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    탭을 오가는 동안 코스 생성 결과·검색어 등이 유지된다(switchWorkTab() 참고). */
 .work-tabbar{display:flex;gap:6px;background:#12141a;border:1px solid var(--border);border-radius:12px;padding:4px;margin-bottom:14px;}
 .work-tab-btn{flex:1;background:transparent;border:0;color:#b7bfcb;padding:10px 6px;border-radius:9px;font-size:13.5px;font-weight:700;cursor:pointer;}
-.work-tab-btn:hover{color:var(--text);}
+.work-tab-btn:hover{color:#fff;}
 .work-tab-btn.active{background:var(--accent);color:#fff;}
 .work-tab-panel{animation:workTabFade .15s ease;}
 @keyframes workTabFade{from{opacity:.4;}to{opacity:1;}}
@@ -591,9 +624,9 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 .work-photo-collage figure{margin:0;border-radius:10px;overflow:hidden;border:1px solid var(--border);}
 .work-photo-collage img{display:block;width:100%;height:120px;object-fit:cover;background:#0c1620;}
 .work-photo-collage figcaption{background:#12141a;padding:4px 8px;}
-.work-photo-collage figcaption a{color:var(--sub);font-size:10px;line-height:1.4;text-decoration:none;display:block;
+.work-photo-collage figcaption a{color:#9aa4b2;font-size:10px;line-height:1.4;text-decoration:none;display:block;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.work-photo-collage figcaption a:hover{color:var(--sub);text-decoration:underline;}
+.work-photo-collage figcaption a:hover{color:#9aa4b2;text-decoration:underline;}
 /* 2026-08 8라운드: 이 사이트의 실제 "모바일 전환" 기준점은 768px다(#main이 지도/정보 세로
    스택으로 바뀌는 지점, 이 파일 하단 @media(max-width:768px) 블록 참고) — 기존엔 520px 한
    단계만 있어서 520~768px 사이 태블릿·큰 폰 폭에서는 여전히 340px짜리 히어로가 그대로 나와
@@ -681,7 +714,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 .social-box .label{display:block;color:#e0c0ff;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;margin-bottom:9px;}
 .social-links{display:flex;flex-wrap:wrap;gap:7px;}
 .social-chip{
-  display:inline-flex;align-items:center;gap:5px;background:#2a2033;border:1px solid #4a3860;color:var(--text);
+  display:inline-flex;align-items:center;gap:5px;background:#2a2033;border:1px solid #4a3860;color:#eee6f7;
   text-decoration:none;font-size:13.5px;font-weight:600;padding:9px 13px;border-radius:999px;
 }
 .social-chip:hover{border-color:#d9a8ff;color:#d9a8ff;}
@@ -693,13 +726,13 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 .people-list{margin-top:14px;}
 .person-chip{
   display:flex;align-items:center;gap:12px;width:100%;text-align:left;
-  background:linear-gradient(135deg,var(--panel2),#242a37);border:1px solid var(--border);
+  background:var(--panel2);border:1px solid var(--border);
   color:var(--text);padding:14px 16px;border-radius:12px;margin-bottom:9px;cursor:pointer;font-size:16px;
   box-shadow:0 2px 10px rgba(0,0,0,.18);transition:transform .12s ease,border-color .12s ease;
 }
 .person-chip:hover{border-color:var(--accent);transform:translateY(-1px);}
 .person-chip .pname{font-weight:800;margin-bottom:3px;font-size:16.5px;}
-.person-chip .pyears{color:#c3cadb;font-size:13.5px;}
+.person-chip .pyears{color:var(--sub);font-size:13.5px;}
 .person-chip .person-chip-text{min-width:0;flex:1;}
 .person-chip .pname,.person-chip .pyears{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 /* ---- 2026-08 등장인물 카드 UI: 실제 스틸/배우 사진을 이 사이트에 직접 게시하지 않는 저작권
@@ -858,7 +891,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 /* ---- 초보자 요약 토글 ---- */
 .desc-toggle{display:flex;gap:6px;margin-bottom:8px;}
 .desc-toggle button{
-  background:#1c2028;border:1px solid var(--border);color:var(--sub);font-size:11px;font-weight:700;
+  background:#1c2028;border:1px solid var(--border);color:#b7bfcb;font-size:11px;font-weight:700;
   padding:4px 10px;border-radius:999px;cursor:pointer;
 }
 .desc-toggle button.active{background:var(--accent);color:#fff;border-color:var(--accent);}
@@ -876,7 +909,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 /* ---- 같은 지역, 다른 이야기 (크로스 작품) ---- */
 .cross-box{background:#1a1f2e;border:1px solid #2c3550;border-radius:10px;padding:12px 15px;margin-bottom:14px;}
 .cross-box .label{display:block;color:#9fb4ff;font-size:11.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;margin-bottom:8px;}
-.cross-box .cross-item{display:block;background:#222a3d;border:1px solid #313c58;border-radius:8px;padding:8px 10px;margin-bottom:6px;color:var(--text);text-decoration:none;font-size:12.5px;cursor:pointer;}
+.cross-box .cross-item{display:block;background:#222a3d;border:1px solid #313c58;border-radius:8px;padding:8px 10px;margin-bottom:6px;color:#e4e8f0;text-decoration:none;font-size:12.5px;cursor:pointer;}
 .cross-box .cross-item:hover{border-color:var(--accent2);}
 .cross-box .cross-item .t{font-weight:700;}
 .cross-box .cross-item .s{color:var(--sub);font-size:11px;}
@@ -912,7 +945,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
    테두리색을 인라인 style로 지정해 쓰므로 그 색은 그대로 유지되고, 배경만 공통으로 밝아진다. */
 .course-btn{
   display:block;width:100%;text-align:center;
-  background:linear-gradient(135deg,#232838,#1a2230);border:1px solid var(--border);color:var(--text);
+  background:linear-gradient(135deg,#232838,#1a2230);border:1px solid var(--border);color:#fff;
   padding:13px;border-radius:12px;cursor:pointer;font-size:14.5px;font-weight:800;margin:10px 0 4px;
   box-shadow:0 2px 8px rgba(0,0,0,.2);transition:transform .12s ease,border-color .12s ease;
 }
@@ -948,7 +981,7 @@ details.course-btn > div .course-btn{margin:0;}
    CTA 바로 아래, 폭 전체를 쓰는 독립 버튼으로 옮겼다(margin-left 제거, 전체 너비). */
 .share-btn{
   display:flex;align-items:center;justify-content:center;gap:6px;width:100%;box-sizing:border-box;
-  background:#2b303b;border:1px solid var(--border);color:var(--text);
+  background:#2b303b;border:1px solid var(--border);color:#fff;
   font-size:13px;font-weight:700;padding:10px 12px;border-radius:8px;cursor:pointer;margin:0 0 14px;
 }
 .share-btn:hover{border-color:var(--accent2);}


### PR DESCRIPTION
- Promote Design System V1 dark/light/accent tokens to :root (previously scoped only to #app.landing for the Issue #19 homepage).
- Migrate the map/header/mobile-tabbar shell to the new dark family via a scoped #app:not(.landing) override, so the already-shipped homepage keeps rendering identically (it never matches that selector).
- Flip #sidebar (== mobile '정보' tab, same element) to the spec's Bright Info Panel by re-scoping --bg/--panel/--panel2/--text/--sub/--border/ --accent2 inside #sidebar, so the file's existing selectors (hero-image, detail-card, person-chip, course-box, work tabs, etc.) pick up the light palette automatically without per-selector edits.
- Fix the handful of components whose colors were hardcoded against the old always-dark sidebar and would have gone low/no-contrast on the new bright surface: person-chip (gradient + years text), course-btn, social-chip, share-btn, cross-box item, desc-toggle, hero-credit link, work-photo-collage caption link, work-tab-btn hover.
- Global --accent now resolves to the DS V1 coral (#FF7B57) on every non-landing screen (map CTAs, course-stop bullets, onboarding hint, offscreen chips, mobile tab active state, era/desc toggles).
- Map: selected location pin is now visually distinguished by size + stroke color (radius 8->12, coral ring) in addition to hue, per MAP_EXPLORER_V1 §8's accessibility note (tracked via new selectedLocId + a 'selected' GeoJSON feature property set in refreshLocationLayer/showLocation).

Preserved as required: MapLibre engine, 58/42 split + draggable resizer, mobile 지도/정보 tab switching, ?work=/location deep links, KR/EN/JP/zh-Hant language switching, SEO/GA4 scripts. No## Summary
Map screen (dark shell + info panel) migrated to Design System V1 per docs/design/MAP_EXPLORER_V1.md. Homepage (#19) and Work Detail (#20) token scopes are untouched.

## Changed files
- site/contentmap_style.css — DS V1 tokens promoted to :root; map/header/mobile-tabbar shell scoped to new dark family via `#app:not(.landing)`; `#sidebar` flipped to the spec's Bright Info Panel via scoped CSS custom-property re-mapping; 9 hardcoded-color fixes for contrast (person-chip, course-btn, social-chip, share-btn, cross-box, desc-toggle, hero-credit, photo-collage caption, work-tab-btn hover).
- - site/contentmap_app.js — selected map pin now distinguished by size + coral stroke (radius 8→12), not color alone (`selectedLocId`, `refreshLocationLayer` `selected` property, `locations-circle` paint spec).
- 
- ## Preserved (unchanged)
- MapLibre engine, 58/42 split + draggable resizer, mobile 지도/정보 tab switching, ?work=/location deep links, KR/EN/JP/zh-Hant language switching, SEO/GA4 scripts, URL/data-model/i18n architecture.
- 
- ## QA
- - `node --check` passes on contentmap_app.js.
- - CSS brace-balance verified (580/580).
- - vm-sandbox load of app.js completes without throwing (top-level init runs clean).
- - Manual audit of every selector touched by the sidebar's dark→light flip for contrast breakage (see commit message for the 9 fixes found/applied).
- - No real browser/screenshot QA available in this environment — 360/390/430/1280/1440/1920 visual QA should be spot-checked before merge.
- 
- ## Known deviations
- Quiz modal colors and the story-progress-bar gradient still use the old orange/blue hex — intentionally left for Issue #23 (Quiz Experience), not in scope here.
- 
- Closes #22 URL/data-model/i18n-architecture changes. Homepage (#19) and Work Detail (#20) token scopes untouched.

Deferred to later Phase 1 stages (explicitly out of scope here): quiz modal styling (#23), place-detail generator (#24), Discovery Hubs (#26), and the shared site shell normalization (#27) — a few decorative hardcoded hex values that belong to those screens (quiz wrong-state, story-progress bar gradient) were intentionally left untouched.

# 변경 요약

## 관련 Issue
- Closes #

## 무엇을 변경했나
- 

## 왜 변경했나
- 

## 검증
- [ ] 로컬/기능 테스트 완료
- [ ] 관련 문서 확인
- [ ] 다국어 영향 확인 (해당 시)
- [ ] SEO 영향 확인 (해당 시)

## AI/개발자 인수인계
### 완료한 것
- 

### 아직 안 한 것
- 

### 다음 한 단계
- 

### 주의사항 / 위험
- 없음

## 프로젝트 상태 반영
- [ ] 관련 Issue 업데이트
- [ ] `docs/PROJECT_STATE.md` 갱신 필요 여부 확인
- [ ] 중요한 결정이면 `docs/DECISIONS.md` 기록
