### PR TITLE
Issue #30: Mobile UX Remediation v1 — corrective pass (Homepage + Work Detail)

### DIFF
--- a/site/contentmap_app.js
+++ b/site/contentmap_app.js
@@ -2347,6 +2347,12 @@ function buildFilterBarHtml(idPrefix){
   const genres = usedValues('genres', true);
   const q = (workFilters.query || '').replace(/"/g, '&quot;');
   const expanded = filterBarExpanded[idPrefix] ? ' expanded' : '';
+  // Issue #30 §4.2: "필터 초기화"는 실제로 적용된 필터/검색어가 있을 때만 노출 — 기본 상태에서는
+  // 검색창+필터 진입 버튼만 보이게 해서 모바일 히어로의 세로 밀도를 낮춘다.
+  const hasActiveFilter = !!(workFilters.country || workFilters.medium || (workFilters.genres && workFilters.genres.size) || (workFilters.query && workFilters.query.trim()));
+  const resetBtnHtml = hasActiveFilter
+    ? '<button type="button" class="filter-reset-btn" id="' + idPrefix + 'FilterReset">' + t('filterResetBtn') + '</button>'
+    : '';
   return '' +
     '<div class="filter-bar' + expanded + '" id="' + idPrefix + 'FilterBar">' +
       '<input type="text" class="filter-search" id="' + idPrefix + 'FilterSearch" placeholder="' + t('filterSearchPlaceholder') + '" value="' + q + '">' +
@@ -2354,7 +2360,7 @@ function buildFilterBarHtml(idPrefix){
       '<div class="filter-group"><span class="filter-group-label">' + t('filterCountryLabel') + '</span><div class="filter-chips">' + chipRowHtml('country', countries, countryLabel, false) + '</div></div>' +
       '<div class="filter-group"><span class="filter-group-label">' + t('filterMediumLabel') + '</span><div class="filter-chips">' + chipRowHtml('medium', mediums, mediumLabel, false) + '</div></div>' +
       '<div class="filter-group"><span class="filter-group-label">' + t('filterGenreLabel') + '</span><div class="filter-chips">' + chipRowHtml('genre', genres, genreLabel, true) + '</div></div>' +
-      '<button type="button" class="filter-reset-btn" id="' + idPrefix + 'FilterReset">' + t('filterResetBtn') + '</button>' +
+      resetBtnHtml +
     '</div>';
 }
 

--- a/site/contentmap_style.css
+++ b/site/contentmap_style.css
@@ -176,6 +176,7 @@ html.gcjg-boot-work #app.landing #main{display:flex;}
 .landing-hero{position:relative;border-radius:24px;overflow:hidden;margin:4px 0 26px;isolation:isolate;color-scheme:dark;background:linear-gradient(115deg,var(--ds-hero-left,#232A38),var(--ds-hero-right,#10141C));}
 /* 좌(헤드라인+CTA) : 우(featured scene 패널) 2열 — 모바일은 아래 @media(max-width:768px)에서 1열로 스택 */
 .landing-hero-grid{position:relative;z-index:2;display:grid;grid-template-columns:1.15fr .85fr;align-items:center;gap:8px;}
+.landing-hero-grid > *{min-width:0;}
 .landing-hero-feature{display:flex;align-items:center;padding:24px 40px 24px 12px;min-height:1px;}
 .landing-hero-collage{position:absolute;inset:0;z-index:0;display:grid;grid-template-columns:repeat(6,1fr);grid-auto-rows:1fr;gap:2px;}
 /* 2026-08 재조정: "누르스름하고 빛바랜 사진 같다"는 피드백 — 기존엔 brightness(.92) saturate(1.05)로
@@ -1144,8 +1145,9 @@ details.course-btn > div .course-btn{margin:0;}
      + 32px짜리 큰 숫자는 한 줄일 때만 예쁘고, 두 줄로 꺾이면 알약이 아니라 둥근 사각형처럼 뭉개져
      보인다. 모바일에서는 글자 크기를 줄이고 모서리도 완전한 알약 대신 적당한 라운드로 낮춰서
      두 줄이 되어도 자연스럽게 보이도록 한다. */
-  .counter-banner-text{font-size:12.5px;padding:8px 14px;border-radius:14px;line-height:1.55;}
-  .counter-banner-num{font-size:22px;}
+  .landing-counter-banner{display:block;}
+  .counter-banner-text{display:block;width:100%;box-sizing:border-box;font-size:13px;padding:12px 16px;border-radius:14px;line-height:1.5;text-align:center;}
+  .counter-banner-num{font-size:26px;}
 
   /* 2026-08 UI 개편(task #431 모바일 재설계): 히어로 콜라주는 칸 수를 줄이고 안쪽 여백도
      좁혀서 헤드라인·카운터 배너·검색창이 화면에 더 빨리(스크롤 없이 가깝게) 보이도록 한다. */
@@ -1165,11 +1167,13 @@ details.course-btn > div .course-btn{margin:0;}
   }
   .hero-collage-tile{filter:brightness(1.05) saturate(1.3) contrast(1.05);}
   .landing-hero-content{padding:28px 16px 20px;}
-  .landing-hero-content h2{font-size:21px;margin:0 0 14px;}
+  .landing-hero-content h2{font-size:22px;margin:0 0 14px;}
   .landing-hero-cta-row{margin-top:16px;}
-  .hero-primary-cta{width:100%;justify-content:center;padding:14px 18px;font-size:14px;}
-  .landing-hero-actions{margin-top:10px;gap:8px;}
-  .hero-action-btn{padding:9px 15px;font-size:12.5px;min-height:44px;}
+  .hero-primary-cta{width:100%;justify-content:center;padding:13px 18px;font-size:14px;min-height:46px;max-height:50px;}
+  /* Issue #30 §4.4: 3개 버튼을 한 줄에 욱여넣지 않고 2열+마지막 버튼 전체폭으로 배치 */
+  .landing-hero-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px;}
+  .hero-action-btn{padding:9px 10px;font-size:12.5px;min-height:44px;justify-content:center;}
+  .landing-hero-actions .hero-action-btn:last-child{grid-column:1 / -1;}
   .hero-today-pick{padding:12px;gap:8px;}
   .hero-today-pick-img{height:120px;}
   .hero-today-pick-title{font-size:14.5px;}

--- a/site/en/works/breakingbad/index.html
+++ b/site/en/works/breakingbad/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/bridgerton/index.html
+++ b/site/en/works/bridgerton/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/byakuya/index.html
+++ b/site/en/works/byakuya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/coffeeprince/index.html
+++ b/site/en/works/coffeeprince/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/conanhighway/index.html
+++ b/site/en/works/conanhighway/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/daejanggeum/index.html
+++ b/site/en/works/daejanggeum/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/daemang/index.html
+++ b/site/en/works/daemang/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/dokkaebi/index.html
+++ b/site/en/works/dokkaebi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/emilyinparis/index.html
+++ b/site/en/works/emilyinparis/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/gameofthrones/index.html
+++ b/site/en/works/gameofthrones/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/glory/index.html
+++ b/site/en/works/glory/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/gwandong/index.html
+++ b/site/en/works/gwandong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/harrypotter/index.html
+++ b/site/en/works/harrypotter/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/hope/index.html
+++ b/site/en/works/hope/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/isatong/index.html
+++ b/site/en/works/isatong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/jikji/index.html
+++ b/site/en/works/jikji/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/kdemonhunters/index.html
+++ b/site/en/works/kdemonhunters/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/kimetsu/index.html
+++ b/site/en/works/kimetsu/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/kiminonawa/index.html
+++ b/site/en/works/kiminonawa/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/littleforest/index.html
+++ b/site/en/works/littleforest/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/lotr/index.html
+++ b/site/en/works/lotr/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/moneyheist/index.html
+++ b/site/en/works/moneyheist/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/namiya/index.html
+++ b/site/en/works/namiya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/odyssey/index.html
+++ b/site/en/works/odyssey/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/onepiece/index.html
+++ b/site/en/works/onepiece/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/pachinko/index.html
+++ b/site/en/works/pachinko/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/poksshak/index.html
+++ b/site/en/works/poksshak/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/prada2/index.html
+++ b/site/en/works/prada2/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/priests/index.html
+++ b/site/en/works/priests/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/santi/index.html
+++ b/site/en/works/santi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/sonyeon/index.html
+++ b/site/en/works/sonyeon/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/spiderman/index.html
+++ b/site/en/works/spiderman/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/squidgame/index.html
+++ b/site/en/works/squidgame/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/strangerthings/index.html
+++ b/site/en/works/strangerthings/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/sunshine/index.html
+++ b/site/en/works/sunshine/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/suspectx/index.html
+++ b/site/en/works/suspectx/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/suzume/index.html
+++ b/site/en/works/suzume/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/taebaek/index.html
+++ b/site/en/works/taebaek/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/wangsanam/index.html
+++ b/site/en/works/wangsanam/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/wednesday/index.html
+++ b/site/en/works/wednesday/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/wintersonata/index.html
+++ b/site/en/works/wintersonata/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/en/works/woo/index.html
+++ b/site/en/works/woo/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/generate_work_pages.js
+++ b/site/generate_work_pages.js
@@ -657,7 +657,8 @@ const SHARED_CSS = `
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/breakingbad/index.html
+++ b/site/ja/works/breakingbad/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/bridgerton/index.html
+++ b/site/ja/works/bridgerton/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/byakuya/index.html
+++ b/site/ja/works/byakuya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/coffeeprince/index.html
+++ b/site/ja/works/coffeeprince/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/conanhighway/index.html
+++ b/site/ja/works/conanhighway/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/daejanggeum/index.html
+++ b/site/ja/works/daejanggeum/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/daemang/index.html
+++ b/site/ja/works/daemang/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/dokkaebi/index.html
+++ b/site/ja/works/dokkaebi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/emilyinparis/index.html
+++ b/site/ja/works/emilyinparis/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/gameofthrones/index.html
+++ b/site/ja/works/gameofthrones/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/glory/index.html
+++ b/site/ja/works/glory/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/gwandong/index.html
+++ b/site/ja/works/gwandong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/harrypotter/index.html
+++ b/site/ja/works/harrypotter/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/hope/index.html
+++ b/site/ja/works/hope/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/isatong/index.html
+++ b/site/ja/works/isatong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/jikji/index.html
+++ b/site/ja/works/jikji/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/kdemonhunters/index.html
+++ b/site/ja/works/kdemonhunters/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/kimetsu/index.html
+++ b/site/ja/works/kimetsu/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/kiminonawa/index.html
+++ b/site/ja/works/kiminonawa/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/littleforest/index.html
+++ b/site/ja/works/littleforest/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/lotr/index.html
+++ b/site/ja/works/lotr/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/moneyheist/index.html
+++ b/site/ja/works/moneyheist/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/namiya/index.html
+++ b/site/ja/works/namiya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/odyssey/index.html
+++ b/site/ja/works/odyssey/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/onepiece/index.html
+++ b/site/ja/works/onepiece/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/pachinko/index.html
+++ b/site/ja/works/pachinko/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/poksshak/index.html
+++ b/site/ja/works/poksshak/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/prada2/index.html
+++ b/site/ja/works/prada2/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/priests/index.html
+++ b/site/ja/works/priests/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/santi/index.html
+++ b/site/ja/works/santi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/sonyeon/index.html
+++ b/site/ja/works/sonyeon/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/spiderman/index.html
+++ b/site/ja/works/spiderman/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/squidgame/index.html
+++ b/site/ja/works/squidgame/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/strangerthings/index.html
+++ b/site/ja/works/strangerthings/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/sunshine/index.html
+++ b/site/ja/works/sunshine/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/suspectx/index.html
+++ b/site/ja/works/suspectx/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/suzume/index.html
+++ b/site/ja/works/suzume/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/taebaek/index.html
+++ b/site/ja/works/taebaek/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/wangsanam/index.html
+++ b/site/ja/works/wangsanam/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/wednesday/index.html
+++ b/site/ja/works/wednesday/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/wintersonata/index.html
+++ b/site/ja/works/wintersonata/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/ja/works/woo/index.html
+++ b/site/ja/works/woo/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/breakingbad/index.html
+++ b/site/works/breakingbad/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/bridgerton/index.html
+++ b/site/works/bridgerton/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/byakuya/index.html
+++ b/site/works/byakuya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/coffeeprince/index.html
+++ b/site/works/coffeeprince/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/conanhighway/index.html
+++ b/site/works/conanhighway/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/daejanggeum/index.html
+++ b/site/works/daejanggeum/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/daemang/index.html
+++ b/site/works/daemang/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/dokkaebi/index.html
+++ b/site/works/dokkaebi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/emilyinparis/index.html
+++ b/site/works/emilyinparis/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/gameofthrones/index.html
+++ b/site/works/gameofthrones/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/glory/index.html
+++ b/site/works/glory/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/gwandong/index.html
+++ b/site/works/gwandong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/harrypotter/index.html
+++ b/site/works/harrypotter/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/hope/index.html
+++ b/site/works/hope/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/isatong/index.html
+++ b/site/works/isatong/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/jikji/index.html
+++ b/site/works/jikji/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/kdemonhunters/index.html
+++ b/site/works/kdemonhunters/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/kimetsu/index.html
+++ b/site/works/kimetsu/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/kiminonawa/index.html
+++ b/site/works/kiminonawa/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/littleforest/index.html
+++ b/site/works/littleforest/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/lotr/index.html
+++ b/site/works/lotr/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/moneyheist/index.html
+++ b/site/works/moneyheist/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/namiya/index.html
+++ b/site/works/namiya/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/odyssey/index.html
+++ b/site/works/odyssey/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/onepiece/index.html
+++ b/site/works/onepiece/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/pachinko/index.html
+++ b/site/works/pachinko/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/poksshak/index.html
+++ b/site/works/poksshak/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/prada2/index.html
+++ b/site/works/prada2/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/priests/index.html
+++ b/site/works/priests/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/santi/index.html
+++ b/site/works/santi/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/sonyeon/index.html
+++ b/site/works/sonyeon/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/spiderman/index.html
+++ b/site/works/spiderman/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/squidgame/index.html
+++ b/site/works/squidgame/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/strangerthings/index.html
+++ b/site/works/strangerthings/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/sunshine/index.html
+++ b/site/works/sunshine/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/suspectx/index.html
+++ b/site/works/suspectx/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/suzume/index.html
+++ b/site/works/suzume/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/taebaek/index.html
+++ b/site/works/taebaek/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/wangsanam/index.html
+++ b/site/works/wangsanam/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/wednesday/index.html
+++ b/site/works/wednesday/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/wintersonata/index.html
+++ b/site/works/wintersonata/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/works/woo/index.html
+++ b/site/works/woo/index.html
@@ -210,7 +210,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/coffeeprince/index.html
+++ b/site/zh/works/coffeeprince/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/daejanggeum/index.html
+++ b/site/zh/works/daejanggeum/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/kdemonhunters/index.html
+++ b/site/zh/works/kdemonhunters/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/poksshak/index.html
+++ b/site/zh/works/poksshak/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/squidgame/index.html
+++ b/site/zh/works/squidgame/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}

--- a/site/zh/works/wintersonata/index.html
+++ b/site/zh/works/wintersonata/index.html
@@ -211,7 +211,8 @@
     .hookBox{padding:18px 16px;border-radius:14px;}
     .hookBox p{font-size:19px;line-height:1.6;}
     .actionBar{flex-direction:column;gap:10px;}
-    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;}
+    .actionBar .ctaBtn{flex:0 0 auto;}
+    .ctaBtn{display:flex;width:100%;text-align:center;font-size:14px;padding:12px 16px;border-radius:10px;margin-bottom:0;min-height:44px;max-height:52px;box-sizing:border-box;}
     h2{font-size:18px;margin:32px 0 14px;}
     .locCard{padding:13px 14px;}
     .locCard h3{font-size:15px;}


### PR DESCRIPTION
## 요약

Closes #30. 실기기 QA(2026-08-28)에서 지적된 두 화면(Homepage, Work Detail)의 모바일 레이아웃 버그를 실브라우저 DOM 측정으로 원인을 특정해 수정했습니다.

### 1. Homepage 우측 텍스트/카드 잘림
`.landing-hero-grid`가 모바일 1열로 붕괴할 때 CSS Grid item의 기본 `min-width:auto`가 자식(`.hero-today-pick-title`, `white-space:nowrap`)의 콘텐츠 폭을 강제하고, 상위 `.landing-hero`의 `overflow:hidden`이 이를 보이지 않게 잘라내고 있었습니다. `document.documentElement.scrollWidth`로는 잡히지 않는 형태의 클리핑이었습니다.

- `.landing-hero-grid > *{min-width:0;}` 추가 (근본 수정)
- 히어로 타이틀 22px, 카운터 배너 1-2줄 블록 구조로 재구성
- 필터 초기화 버튼은 실제 필터 적용 시에만 노출
- 히어로 CTA를 46-50px 버튼으로, 보조 액션 3개는 2열 그리드 + 3번째 버튼 전체폭으로 재배치

### 2. Work Detail 큰 빈 카드에 한 줄짜리 정보
`.actionBar .ctaBtn`의 `flex-basis:220px`가 가로 레이아웃 기준값인데, `@media(max-width:480px)`에서 `.actionBar`가 `flex-direction:column`으로 전환되면서 그대로 220px 높이로 적용되고 있었습니다. media query 밖의 규칙이 안쪽 규칙보다 specificity가 높아 모바일 오버라이드가 무력화된 것도 원인이었습니다. ko/en/ja/zh 4개 언어 페이지 전체에서 동일하게 재현 확인.

- `.actionBar .ctaBtn{flex:0 0 auto;}` 추가로 flex-basis 무력화
- `.ctaBtn`에 `min-height:44px;max-height:52px;box-sizing:border-box;`
- `generate_work_pages.js` 원본 수정 후, 이미 생성된 132개 정적 페이지에는 콘텐츠 재생성 없이 CSS 두 줄만 정밀 치환 (데이터 재생성 시 무관한 콘텐츠 드리프트가 섞이는 것을 확인하고 이 방식으로 전환)

## QA / 환경 제약 (투명 공개)

이 개발 환경에서는 픽셀 스크린샷 캡처가 불가능합니다(Browser pane이 compositing되지 않아 항상 실패, Playwright Chromium 다운로드도 네트워크 allowlist에 의해 차단). 대신 라이브 프로덕션 사이트(수정 전)에 대해 실브라우저 DOM 측정(`getBoundingClientRect`/`getComputedStyle`/`scrollWidth`)으로 두 버그를 수치로 확정했고, 수정된 정적 파일은 grep으로 의도한 두 줄만 반영됐는지 검증했습니다.

- 360/390/430px 모두 `document.documentElement.scrollWidth <= window.innerWidth`, `document.body.scrollWidth <= window.innerWidth` 확인 (가로 스크롤 없음)
- ko/en/ja/zh 4개 언어 모두 동일 버그 재현 및 동일 수정 적용 확인

## 범위

Homepage/Work Detail 모바일 CSS·레이아웃 수정에 한정. URL/SEO/데이터 모델/배포 아키텍처는 변경하지 않음 (Issue #30 §13).

**운영 배포는 이 PR에 포함되어 있지 않습니다.** 로컬 검증용 배포 ZIP만 별도로 준비했습니다.